### PR TITLE
changing controller to work on mono

### DIFF
--- a/src/Areas/Admin/Controllers/ElmahController.cs
+++ b/src/Areas/Admin/Controllers/ElmahController.cs
@@ -79,7 +79,7 @@ namespace ElmahMvc.Areas.Admin.Controllers
                                                 context.HttpContext.Request.QueryString.ToString());
             }
 
-            var currentContext = GetCurrentContext(context);
+            var currentContext = GetCurrentContextAsHttpContext(context);
 
             var httpHandler = factory.GetHandler(currentContext, null, null, null);
             var httpAsyncHandler = httpHandler as IHttpAsyncHandler;
@@ -93,15 +93,9 @@ namespace ElmahMvc.Areas.Admin.Controllers
             httpHandler.ProcessRequest(currentContext);
         }
 
-        private static HttpContext GetCurrentContext(ControllerContext context)
+        private static HttpContext GetCurrentContextAsHttpContext(ControllerContext context)
         {
-            var currentApplication = (HttpApplication) context.HttpContext.GetService(typeof (HttpApplication));
-            if (currentApplication == null)
-            {
-                throw new NullReferenceException("currentApplication");
-            }
-
-            return currentApplication.Context;
+            return context.HttpContext.ApplicationInstance.Context;
         }
 
         private string FilePath(ControllerContext context)


### PR DESCRIPTION
HttpContext.GetService method is not implemented on mono.  This changes ElmahResult to retrieve ControllerContext's HttpContext(Base) as an 'old school' HttpContext without using said method (as suggested [here](http://stackoverflow.com/a/4567707/794))
