### PR TITLE
Interface for injecting custom authorization

### DIFF
--- a/src/Elmah.Mvc/AuthorizeAttribute.cs
+++ b/src/Elmah.Mvc/AuthorizeAttribute.cs
@@ -20,6 +20,7 @@
 //
 
 using System.Linq;
+using System.Web.Mvc;
 
 namespace Elmah.Mvc
 {
@@ -42,10 +43,18 @@ namespace Elmah.Mvc
 
         protected override bool AuthorizeCore(System.Web.HttpContextBase httpContext)
         {
-            return !_isHandlerDisabled
-                   && (!_requiresAuthentication
-                       || (httpContext.Request.IsAuthenticated
-                           && _allowedRoles.Any(r => r == "*" || httpContext.User.IsInRole(r))));
+            var authorizationProviderForElmah =
+                DependencyResolver.Current.GetService<IAuthorizerForElmah>();
+
+            if (authorizationProviderForElmah == null)
+            {
+                return !_isHandlerDisabled
+                       && (!_requiresAuthentication
+                           || (httpContext.Request.IsAuthenticated
+                               && _allowedRoles.Any(r => r == "*" || httpContext.User.IsInRole(r))));
+            }
+
+            return authorizationProviderForElmah.IsAuthorizedForElmah(httpContext.User.Identity.Name);
         }
     }
 }

--- a/src/Elmah.Mvc/Elmah.Mvc.csproj
+++ b/src/Elmah.Mvc/Elmah.Mvc.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elmah">
-      <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -49,6 +49,7 @@
     <Compile Include="ElmahController.cs" />
     <Compile Include="ElmahResult.cs" />
     <Compile Include="HandleErrorAttribute.cs" />
+    <Compile Include="IAuthorizerForElmah.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.cs" />
   </ItemGroup>

--- a/src/Elmah.Mvc/IAuthorizerForElmah.cs
+++ b/src/Elmah.Mvc/IAuthorizerForElmah.cs
@@ -1,0 +1,10 @@
+﻿namespace Elmah.Mvc
+{
+    /// <summary>
+    ///   TODO: Update summary.
+    /// </summary>
+    public interface IAuthorizerForElmah
+    {
+        bool IsAuthorizedForElmah(string userName);
+    }
+}

--- a/src/Elmah.Mvc/Settings.cs
+++ b/src/Elmah.Mvc/Settings.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // ELMAH.Mvc
 // Copyright (c) 2011 Atif Aziz, James Driscoll. All rights reserved.
 //


### PR DESCRIPTION
I added an interface so that you can inject your own authorization implementation.
We needed this in our project since we were using custom authorization code.

How to use it:
1) Create class implementing the IAuthorizerForElmah interface, which is just the single method IsAuthorizedForElmah(username). In this method you can write your own code for determining whether this user is authorized to use elmah.
2) Inject the class using the Dependency Injection framework you are using in your project. (Elmah.mvc will find the class using the DependencyResolver)
