### PR TITLE
Added null check for Elmah http handler.

### DIFF
--- a/src/Elmah.Mvc/ElmahResult.cs
+++ b/src/Elmah.Mvc/ElmahResult.cs
@@ -65,7 +65,10 @@ namespace Elmah.Mvc
 
             var unwrappedHttpContext = httpContext.ApplicationInstance.Context;
             var handler = new ErrorLogPageFactory().GetHandler(unwrappedHttpContext, null, null, null);
-            handler.ProcessRequest(unwrappedHttpContext);
+            if(handler != null)
+            {
+                handler.ProcessRequest(unwrappedHttpContext);
+            }
         }
     }
 }


### PR DESCRIPTION
When any registered instance of Elmah's IRequestAuthorizationHandler interface fails authorization or Elmah is not configured to allow remote access, it will set the status code to 403 and return null.

Calling ProcessRequest on a null handler causes a NullReferenceException which is logged and emailed.
