### PR TITLE
Changing authorize attribute to support roles or usernames

### DIFF
--- a/src/Elmah.Mvc/AuthorizeAttribute.cs
+++ b/src/Elmah.Mvc/AuthorizeAttribute.cs
@@ -60,7 +60,7 @@ namespace Elmah.Mvc
         private bool UserIsAllowed(System.Web.HttpContextBase httpContext)
         {
 
-            return UserIsAllowedByRole(httpContext) && UserIsAllowedByName(httpContext);
+            return UserIsAllowedByRole(httpContext) || UserIsAllowedByName(httpContext);
         }
 
         /// <summary>


### PR DESCRIPTION
This allows the implementer to permit a role without needing to have an explicit list of usernames accompanying the role.
