### PR TITLE
Also ignore /elmah route under folders if IgnoreDefaultRoute is true

### DIFF
--- a/src/Elmah.Mvc/Bootstrap.cs
+++ b/src/Elmah.Mvc/Bootstrap.cs
@@ -67,6 +67,7 @@ namespace Elmah.Mvc
             {
                 routes.IgnoreRoute("elmah");
                 routes.IgnoreRoute("elmah/{*pathinfo}");
+                routes.IgnoreRoute("{*elmahinsubfolder}", new { elmahinsubfolder = @".*/elmah(/.*)?" });
             }
         }
     }


### PR DESCRIPTION
Using the scanner at https://asafaweb.com/ I notice that elmah was still accessible under a subfolder.

The root of my application redirects to a culturecode `/nl-be`. 
The scanner detected that `/nl-be/elmah` is accessible, although `IgnoreDefaultRoute` is on and `/elmah` itself is not accessible.