### PR TITLE
Allow IgnoreDefaultRoute to work for routes other than /elmah

### DIFF
--- a/src/Elmah.Mvc/Bootstrap.cs
+++ b/src/Elmah.Mvc/Bootstrap.cs
@@ -63,11 +63,11 @@ namespace Elmah.Mvc
                 null,
                 namespaces);
 
-            if (elmahRoute != "elmah" && Settings.IgnoreDefaultRoute)
+            if (Settings.IgnoreDefaultRoute)
             {
-                routes.IgnoreRoute("elmah");
-                routes.IgnoreRoute("elmah/{*pathinfo}");
-                routes.IgnoreRoute("{*elmahinsubfolder}", new { elmahinsubfolder = @".*/elmah(/.*)?" });
+                routes.IgnoreRoute(elmahRoute);
+                routes.IgnoreRoute(elmahRoute + "/{*pathinfo}");
+                routes.IgnoreRoute("{*elmahinsubfolder}", new { elmahinsubfolder = string.Format(@".*/{0}(/.*)?", elmahRoute) });
             }
         }
     }


### PR DESCRIPTION
The IgnoreRoute statements seem to be hard coded to use the /elmah/ route. This code uses the value in the elmah.mvc.route app setting to make the IgnoreRoute's statements dynamic, so that the default route can be changed and IgnoreRoute will still work.