### PR TITLE
/.vs added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ tests/*
 doc/*
 SolutionVersion.cs
 gems/lib/**/*
+/src/.vs/*


### PR DESCRIPTION
Since Visual studio 2017 we need to add dubdir .vs to gitignore. See https://stackoverflow.com/a/45016792/426361
